### PR TITLE
Add support PHP 7.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
   ],
   "require": {
     "php": ">=7.0",
-    "ltd-beget/stringstream" : "~1.0.2"
+    "ltd-beget/stringstream" : "~1.1.0"
   },
   "require-dev": {
     "theseer/phpdox": "0.8.*",


### PR DESCRIPTION
Привет, в PHP 7.4 падает с TypeError из-за работы stringstream с ArrayIterator как обычным массивом.
Поменял функции массивов на методы ArrayIterator.
Ваш коллега принял пул в stringstream.
Тесты sphinx-configuration-tokenizer проходят.